### PR TITLE
add validation to ensure title or description cannot be empty

### DIFF
--- a/coast/road/views.py
+++ b/coast/road/views.py
@@ -72,6 +72,10 @@ def report(request, typ, id):
 def add_report(request):
     description  = request.POST['description']
     title = request.POST['title']
+    if description == '' or title == '':
+        return JsonResponse({
+            'error': 'Title or description cannot be empty'
+        }, status=400)
     reporter_name = request.POST['reporter_name']
     frame_base64 = request.POST['frame_base64']
     video = request.POST['video']

--- a/templates/video.html
+++ b/templates/video.html
@@ -56,6 +56,9 @@
   <div class="form-field-block js-submit-div">
     <button id="submit" class="btn">Submit Report</button>
   </div>
+  <div class="form-field-block js-submit-message hide">
+
+  </div> 
 </form>
 {% if existing_reports %}
   <div class="container-sm">


### PR DESCRIPTION
fixes #7 

@moahmed ideally would do validation a bit better, but this should ensure we don't get reports with empty titles or descriptions, and that we show those errors to the user.